### PR TITLE
Unified JSON web frontend

### DIFF
--- a/www-services/FunctionsService.hs
+++ b/www-services/FunctionsService.hs
@@ -25,7 +25,8 @@ import System.IO.Unsafe ( unsafePerformIO )
 import System.FilePath
 import System.Directory ( doesFileExist )
 import Text.JSON
-import Text.JSON.Types (JSObject(..))
+import Text.JSON.String (runGetJSON)
+import Text.JSON.Types (get_field, JSObject(..), JSValue(..))
 import Database.Daison
 import SenseSchema
 
@@ -56,15 +57,19 @@ functionsService db gr mn sgr rq =
                       (lookup "qid" (fromJSObject query))
       lang <- valFromObj "lang" query
       code <- valFromObj "code" query
-      return (executeCode db gr sgr mn True mb_qid lang code)
-
-    orFail :: String -> Maybe a -> Result a
-    orFail s = maybe (fail s) pure
+      cs <- case valFromObj "choices" query of
+        Ok json -> orFailErr $ deserializeChoices json
+        Error _ -> return Map.empty
+      return (executeCode db gr sgr mn OutJSON mb_qid lang cs code)
 
     getFromQuery query = do
       lang <- orFail "No lang" $ lookup "lang" query
       code <- orFail "No code" $ lookup "code" query
-      return $ executeCode db gr sgr mn True (lookup "qid" query) lang code
+      cs <- case lookup "choices" query of
+        Just s  -> do json <- orFailE $ runGetJSON readJSArray s
+                      orFailErr $ deserializeChoices json
+        Nothing -> return Map.empty
+      return $ executeCode db gr sgr mn OutJSON (lookup "qid" query) lang cs code
 
 pageService :: Database -> PGF -> ModuleName -> SourceGrammar -> FilePath -> Request -> IO Response
 pageService db gr mn sgr path rq = do
@@ -77,7 +82,7 @@ pageService db gr mn sgr path rq = do
                    case rsp >>= get_classes of
                      Ok classes -> case [prog | cls <- classes, (cls',prog) <- config :: [(String,String)], cls==cls'] of
                                      (prog:_) -> do code <- readFile (dir </> prog)
-                                                    rsp <- executeCode db gr sgr mn False (Just qid) lang code
+                                                    rsp <- executeCode db gr sgr mn OutTable (Just qid) lang Map.empty code
                                                     let code_doc =
                                                           case lookup "edit" query of
                                                             Just _  -> showXMLDoc (Data code)
@@ -117,30 +122,43 @@ pageService db gr mn sgr path rq = do
       injectTemplate ('<':'%':'o':'u':'t':'p':'u':'t':'%':'>':cs) qid prog code output = output ++ injectTemplate cs qid prog code output
       injectTemplate (c:cs)                                       qid prog code output = c :       injectTemplate cs qid prog code output
 
-executeCode :: Database -> PGF -> SourceGrammar -> ModuleName -> Bool -> Maybe String -> String -> String -> IO Response
-executeCode db gr sgr mn as_table mb_qid lang code =
+data ExecOutFormat = OutJSON | OutTable
+
+executeCode :: Database      -- ^ Database for wiki data
+            -> PGF           -- ^ Ambient core grammar
+            -> SourceGrammar -- ^ Ambient grammar
+            -> ModuleName    -- ^ Name of the predef module to open
+            -> ExecOutFormat -- ^ Output format
+            -> Maybe String  -- ^ Ambient QID
+            -> String        -- ^ Ambient language
+            -> ChoiceMap     -- ^ Initial choices (i.e. a program trace)
+            -> String        -- ^ Code snippet to execute
+            -> IO Response
+executeCode db gr sgr mn fmt mb_qid lang csInit code =
   case runLangP NLG pNLG (BS.pack code) of
     Right prog ->
       case runCheck (checkComputeProg (maybe prog (add_qid prog) mb_qid)) of
-        E.Ok (res,msg)
-          | as_table
-                   -> return (Response
+        E.Ok (res,msg) -> case fmt of
+          OutJSON  -> return (Response
                                 { rspCode = 200
                                 , rspReason = "OK"
                                 , rspHeaders = [Header HdrContentType "application/json; charset=UTF8"]
                                 , rspBody = encode $
                                               makeObj [("msg",showJSON msg)
                                                       ,("groups", showJSON [makeObj [("headers",showJSON headers),
-                                                                                     ("dataset",showJSON dataset)]
+                                                                                     ("dataset",JSArray [makeObj [ ("fields",showJSON fs)
+                                                                                                                 , ("choices",serializeChoices cs)
+                                                                                                                 , ("options",ois)
+                                                                                                                 ]
+                                                                                                           | (fs,cs,ois) <- dataset])]
                                                                               | (headers,dataset) <- res])
                                                       ]
                                 })
-          | otherwise
-                   -> return (Response
+          OutTable -> return (Response
                                 { rspCode = 200
                                 , rspReason = "OK"
                                 , rspHeaders = [Header HdrContentType "text/html; charset=UTF8"]
-                                , rspBody = concat [concat html | (headers,(html:_)) <- res]
+                                , rspBody = concat [concat html | (headers,((html,_,_):_)) <- res] -- TODO options
                                 })
         E.Bad msg  -> return (Response
                                 { rspCode = 400
@@ -198,12 +216,12 @@ executeCode db gr sgr mn as_table mb_qid lang code =
           globals1 = Gl sgr' (wikiPredef db gr lang sgr')
           qident = (nlg_mn,identS "main")
 
-      res <- runEvalM globals1 $ do
+      res <- runEvalMWithOpts globals1 csInit $ do
         g <- globals
         let (c1,c2) = split unit
         (term,res_ty) <- inferLType' (Q qident)
         (flag,term,res_ty) <- instantiate False term res_ty
-        res <- value2termM False [] (bubble (eval g [] c2 term []))
+        res <- value2termM True [] (eval g [] c2 term [])
         res <- case res of
                  FV ts -> msum (map return ts)
                  res   -> return res
@@ -212,8 +230,12 @@ executeCode db gr sgr mn as_table mb_qid lang code =
                           else return (res,res_ty)
         res_ty <- value2termM True [] res_ty
         res <- toRecord res_ty res
-        return (toHeaders res_ty,[res])
-      return ((Map.toList . fmap reverse . Map.fromListWith (++)) res)
+        return (toHeaders res_ty,res)
+      res <- forM res $ \((hs,r),cs,ois) -> do
+        ois <- orFailM "No result while serializing option info" $
+          listToMaybe <$> runEvalM globals1 (serializeOptionInfo ois)
+        return (hs,[(r,cs,ois)])
+      return $ Map.toList (fmap reverse (Map.fromListWith (++) res))
 
     toHeaders (RecType lbls) = [toHeader (pp l <+> ':') ty | (l,ty) <- lbls]
     toHeaders ty             = [toHeader empty ty]
@@ -263,6 +285,21 @@ executeCode db gr sgr mn as_table mb_qid lang code =
       | isPGFType ty = do e <- toExpr [] t
                           return (showExpr [] e)
       | otherwise    = return (render (ppTerm Unqualified 0 t))
+
+    serializeOptionInfo ois = do
+      rs <- forM ois $ \(OptionInfo c lty l os) -> do
+        lty   <- value2termM True [] lty
+        l     <- value2termM True [] l
+        label <- toCell lty l
+        os <- forM os $ \(oty,o) -> do
+          oty <- value2termM True [] oty
+          o   <- value2termM True [] o
+          toCell oty o
+        return $ makeObj [ ("label"  , showJSON label)
+                         , ("choice" , showJSON (unchoice c))
+                         , ("options", showJSON os)
+                         ]
+      return $ JSArray rs
 
     isPGFType (QC (m,c))
       | m == abs_mn = True
@@ -341,6 +378,29 @@ executeCode db gr sgr mn as_table mb_qid lang code =
 
          mkInfo locd loct (de',ty') = (ResOper (Just (L locd ty')) (Just (L locd de')))
 
+orFail s = maybe (fail s) pure
+
+orFailM s = (orFail s =<<)
+    
+orFailE = either fail pure
+
+orFailErr (E.Ok a)    = return a
+orFailErr (E.Bad err) = fail err
+
+serializeChoices :: ChoiceMap -> JSValue
+serializeChoices cs = JSArray (Map.toList cs >>= \(c,i) -> [showJSON (unchoice c), showJSON i])
+
+deserializeChoices :: JSValue -> E.Err ChoiceMap
+deserializeChoices json = case readJSON json of
+  Error err -> E.Bad err
+  Ok cs     -> Map.fromList <$> parse cs
+  where
+    parse []       = E.Ok []
+    parse [x]      = E.Bad "Choice array must have even length!"
+    parse (c:i:cs) = do
+      rs <- parse cs
+      return $ (Choice c, fromInteger i) : rs
+
 wikiPredef :: Database -> PGF -> String -> Grammar -> PredefTable
 wikiPredef db pgf lang gr = Map.fromList
   [ (identS "entity", pdArity 2 $\ \g c [typ,qid] -> Const (fetch c typ qid))
@@ -373,7 +433,7 @@ wikiPredef db pgf lang gr = Map.fromList
       case unsafePerformIO (wikidataEntity qid) of
         Ok obj    -> filterJsonFromType c obj typ lang
         Error msg -> VError (pp msg)
-    fetch c ty (VFV c1 (VarFree vs)) = VFV c1 (VarFree (mapC (\c -> fetch c ty) c vs))
+    fetch c ty (VFV c1 vs) = VFV c1 (mapVariantsC (\c -> fetch c ty) c vs)
 
     -- add lang -> synsets, give both options for lex and syn
     get_expr l c ty (VStr qid) =
@@ -405,8 +465,8 @@ wikiPredef db pgf lang gr = Map.fromList
           mod == abstr && showIdent cat1 == cat2
         matchType (VMeta _ _) _ = True
         matchType _ _ = False
-    get_expr l c ty (VFV c1 (VarFree vs)) = VFV c1 (VarFree (mapC (\c -> get_expr l c ty) c vs))
-    get_expr l c ty qid                   = VError (ppValue Unqualified 0 (VApp c (cPredef,identS "expr") [ty, qid]))
+    get_expr l c ty (VFV c1 vs) = VFV c1 (mapVariantsC (\c -> get_expr l c ty) c vs)
+    get_expr l c ty qid         = VError (ppValue Unqualified 0 (VApp c (cPredef,identS "expr") [ty, qid]))
 
     get_gendered_expr l c ty (VStr qid) (VStr gender) =
       case res of
@@ -681,7 +741,7 @@ int2digits abstr c (VInt n)
     rest n t =
       let (n2,n1) = divMod n 10
       in rest n2 (VApp c iidig [digit n1, t])
-int2digits abstr c (VFV c1 (VarFree vs)) = VFV c1 (VarFree (map (int2digits abstr c) vs))
+int2digits abstr c (VFV c1 vs) = VFV c1 (mapVariants (int2digits abstr c) vs)
 
 int2decimal :: ModuleName -> Choice -> Value -> Value
 int2decimal abstr c (VInt n) = sign n (int2digits abstr c (VInt (abs n)))
@@ -692,7 +752,7 @@ int2decimal abstr c (VInt n) = sign n (int2digits abstr c (VInt (abs n)))
     sign n t
       | n < 0     = VApp c neg_dec [t]
       | otherwise = VApp c pos_dec [t]
-int2decimal abstr c (VFV c1 (VarFree vs)) = VFV c1 (VarFree (map (int2decimal abstr c) vs))
+int2decimal abstr c (VFV c1 vs) = VFV c1 (mapVariants (int2decimal abstr c) vs)
 int2decimal abstr c _ = VFV c (VarFree [])
 
 float2decimal :: ModuleName -> Choice -> Value -> Value
@@ -719,7 +779,7 @@ float2decimal abstr c (VFlt f) =
     fractions v (d:ds) = fractions (VApp c ifrac [v, digit d]) ds
 
     digit d = (VApp c (abstr,identS ('D':'_':show d)) [])
-float2decimal abstr c (VFV c1 (VarFree vs)) = VFV c1 (VarFree (map (float2decimal abstr c) vs))
+float2decimal abstr c (VFV c1 vs) = VFV c1 (mapVariants (float2decimal abstr c) vs)
 float2decimal abstr c _ = VFV c (VarFree [])
 
 int2numeral abstr c (VInt n)
@@ -776,7 +836,7 @@ int2numeral abstr c (VInt n)
     app0 fn = VApp c (abstr,identS fn) []
     app1 fn v1 = VApp c (abstr,identS fn) [v1]
     app2 fn v1 v2 = VApp c (abstr,identS fn) [v1,v2]
-int2numeral abstr c (VFV c1 (VarFree vs)) = VFV c1 (VarFree (map (int2numeral abstr c) vs))
+int2numeral abstr c (VFV c1 vs) = VFV c1 (mapVariants (int2numeral abstr c) vs)
 
 time2adv abs_mn c (VStr s) =
   case matchISO8601 s of
@@ -824,7 +884,7 @@ time2adv abs_mn c (VStr s) =
         digit r c
           | isDigit c = fmap (\x -> (x*10+(fromIntegral (ord c - ord '0')))) r
           | otherwise = Nothing
-time2adv abs_mn c (VFV c1 (VarFree vs)) = VFV c1 (VarFree (map (time2adv abs_mn c) vs))
+time2adv abs_mn c (VFV c1 vs) = VFV c1 (mapVariants (time2adv abs_mn c) vs)
 
 toBool c True  = VApp c (cPredef,identS "True")  []
 toBool c False = VApp c (cPredef,identS "False") []

--- a/www/gf-functions.html
+++ b/www/gf-functions.html
@@ -26,6 +26,33 @@
             #editor {
                 border: 1px solid silver;
             }
+
+            #options {
+                position: fixed;
+                top: 25vh;
+                right: 0;
+                padding: 24px 5vw 24px 32px;
+                background-color: #ddd;
+            }
+
+            #options:empty {
+                display: none;
+            }
+
+            .option-container {
+                display: flex;
+                flex-flow: column;
+                gap: 8px;
+            }
+
+            .option-value {
+                margin-left: 0.5em;
+                cursor: pointer;
+            }
+
+            .option-value:hover, .option-value.selected {
+                background-color: #cce;
+            }
         </style>
     </head>
     <body>
@@ -324,6 +351,8 @@
         <tr><td colspan=2><div id='output' style="width: 500px; height: 300px"></div></td></tr>
         </table>
 
+        <div id="options"></div>
+
         <script>
             const evalBtn = document.getElementById("eval");
             evalBtn.addEventListener("click", test);
@@ -331,57 +360,12 @@
             const editor = CodeMirror(document.getElementById('editor'),{lineNumbers: true, mode: "haskell", matchBrackets: true});
             editor.setSize(null,  300);
 
+            const state = new WordNetPageState(document.getElementById("output"), document.getElementById("options"));
+
             async function test() {
                 const selection = getMultiSelection(element('from'));
                 const content   = document.getElementById("content");
-                const data = {
-                    lang: selection.current,
-                    code: editor.getValue()
-                };
-                if (content.dataset.qid != null)
-                    data.qid = content.dataset.qid;
-                const response = await fetch("FunctionsService.fcgi",
-                    {method: "POST",
-                     body: JSON.stringify(data),
-                    });
-                output.innerHTML = "";
-                if (response.status == 200) {
-                    const result = await response.json();
-                    output.appendChild(node("pre",{},[text(result.msg)]));
-                    if (result.groups.length == 0)
-                        output.appendChild(node("b",{},[text("No results")]));
-                    for (var group of result.groups) {
-                        const res_tbl = node("table",{"class": "dataset"},[]);
-                        const row = []
-                        for (var header of group.headers) {
-                            row.push(th([text(header.label)]));
-                        }
-                        res_tbl.appendChild(tr(row))
-                        for (var record of group.dataset) {
-                            const row = []
-                            for (let i in record) {
-                                const value  = record[i];
-                                const header = group.headers[i];
-                                if (header.type == "markup") {
-                                    const e = td([]);
-                                    e.innerHTML = value;
-                                    row.push(e);
-                                } else if (header.type == "number") {
-                                    row.push(node("td",{style: "text-align: right"},[text(value)]));
-                                } else if (header.type == "string") {
-                                    row.push(td([text(value)]));
-                                } else if (header.type == "text") {
-                                    row.push(td(node("pre",{},[text(value)])));
-                                }
-                            }
-                            res_tbl.appendChild(tr(row))
-                        }
-                        output.appendChild(res_tbl);
-                    }
-                } else {
-                    const message = await response.text();
-                    output.appendChild(node("pre",{},[text(message)]));
-                }
+                state.setProgram(content.dataset.qid, selection.current, editor.getValue());
             }
 
             initMultiSelection(element("from"));

--- a/www/gf-functions.html
+++ b/www/gf-functions.html
@@ -348,6 +348,7 @@
         </tr>
 
         <tr><td id='editor' colspan=2></td></tr>
+        <tr><td colspan=2><div id='msgs' style="width: 500px"></div></td></tr>
         <tr><td colspan=2><div id='output' style="width: 500px; height: 300px"></div></td></tr>
         </table>
 
@@ -360,12 +361,100 @@
             const editor = CodeMirror(document.getElementById('editor'),{lineNumbers: true, mode: "haskell", matchBrackets: true});
             editor.setSize(null,  300);
 
-            const state = new WordNetPageState(document.getElementById("output"), document.getElementById("options"));
+            const elemMsgs = document.getElementById("msgs");
+            const elemOut = document.getElementById("output");
+            const elemOpts = document.getElementById("options");
+
+            function renderGroup(group) {
+                const res_tbl = node("table",{"class": "dataset"},[]);
+                const row = []
+                for (const header of group.headers) {
+                    row.push(th([text(header.label)]));
+                }
+                res_tbl.appendChild(tr(row))
+                for (const record of group.dataset) {
+                    const row = []
+                    for (let i in record.fields) {
+                        const value  = record.fields[i];
+                        const header = group.headers[i];
+                        if (header.type == "markup") {
+                            const e = td([]);
+                            e.innerHTML = value;
+                            row.push(e);
+                        } else if (header.type == "number") {
+                            row.push(node("td",{style: "text-align: right"},[text(value)]));
+                        } else if (header.type == "string") {
+                            row.push(td([text(value)]));
+                        } else if (header.type == "text") {
+                            row.push(td(node("pre",{},[text(value)])));
+                        }
+                    }
+                    const rec = tr(row);
+                    rec.onclick = () => client.setInteractionPoint(group.headers, record);
+                    res_tbl.appendChild(rec);
+                }
+                elemOut.appendChild(res_tbl);
+            }
+
+            const client = new WNClient();
+            client.addEventListener("state", event => {
+                const state = event.newState;
+                switch (state.state) {
+                    case "invalid":
+                        elemOut.innerHTML = `<pre class="status">${state.error}</pre>`;
+                        break;
+                    case "valid":
+                        switch (state.groups.length) {
+                            case 0:
+                                elemOut.innerHTML = "<b>No results</b>";
+                                elemOpts.innerHTML = "";
+                                break;
+                            case 1:
+                                const group = state.groups[0];
+                                if (group.dataset.length === 1) {
+                                    client.setInteractionPoint(group.headers, group.dataset[0]);
+                                    break;
+                                }
+                                // falls through
+                            default:
+                                elemOut.innerHTML = "";
+                                elemOpts.innerHTML = "";
+                                for (const group of state.groups) {
+                                    renderGroup(group);
+                                }
+                                break;
+                        }
+                        break;
+                    case "interactive":
+                        elemOut.innerHTML = "";
+                        elemOpts.innerHTML = "";
+                        renderGroup({ headers: state.headers, dataset: [state.record] });
+                        const optElems = [];
+                        const validOptChoices = new Set();
+                        for (const opt of state.record.options) {
+                            const optBody = [node("div", { "class": "option-header" }, [node("b", {}, [text(opt.label)])])];
+                            const selected = state.opts[opt.choice] || 0;
+                            for (let i = 0; i < opt.options.length; i++) {
+                                const valueElem = node("div", { "class": "option-value" }, [text(opt.options[i])]);
+                                if (i === selected) valueElem.classList.add("selected");
+                                valueElem.onclick = () => client.setOption(opt.choice, i);
+                                optBody.push(valueElem)
+                            }
+                            optElems.push(node("div", { "class": "option" }, optBody));
+                        }
+                        elemOpts.appendChild(node("div", { "class": "option-container" }, optElems));
+                        break;
+                }
+            });
+            client.addEventListener("result", event => {
+                elemMsgs.innerHTML = "";
+                elemMsgs.appendChild(node("pre",{},[text(event.result.msg)]));
+            });
 
             async function test() {
                 const selection = getMultiSelection(element('from'));
                 const content   = document.getElementById("content");
-                state.setProgram(content.dataset.qid, selection.current, editor.getValue());
+                client.setProgram(content.dataset.qid, selection.current, editor.getValue());
             }
 
             initMultiSelection(element("from"));

--- a/www/js/gf-functions.d.ts
+++ b/www/js/gf-functions.d.ts
@@ -1,0 +1,297 @@
+/*
+ * SERVER RESPONSE OBJECTS
+ */
+
+/**
+ * A mapping from choice IDs (as integer strings) to choice indices.
+ */
+type ChoiceMap = { [string]?: number }
+
+/**
+ * A series of pairs of choice IDs and choice indices. As such, the length of the array must be even.
+ */
+type ChoiceArray = number[]
+
+/**
+ * Serializes a choice map to a choice array.
+ */
+declare function serializeChoices(obj: ChoiceMap): ChoiceArray;
+
+/**
+ * Deserializes a choice map from a choice array.
+ */
+declare function deserializeChoices(arr: ChoiceArray): ChoiceMap;
+
+/**
+ * A header for a field of a type.
+ */
+type VariantFieldHeader = {
+  /**
+   * The human-readable name and type of the field, or just the type of a non-record type.
+   */
+  label: string,
+  
+  /**
+   * How values of this field should be rendered.
+   */
+  type: "string" | "text" | "number" | "markup"
+}
+
+/**
+ * Information about an option selection.
+ */
+type OptionInfo = {
+  /**
+   * The label for the option; usually a question or prompt.
+   */
+  label: string,
+
+  /**
+   * The choice ID for the option.
+   */
+  choice: number,
+
+  /**
+   * The labels for the option choices.
+   */
+  options: string[]
+}
+
+/**
+ * A record representing a single variant.
+ */
+type VariantRecord = {
+  /**
+   * The values of the record's fields.
+   * Interpretation of the strings depends on the field type.
+   * 
+   * @see VariantFieldHeader#type
+   */
+  fields: string[],
+
+  /**
+   * The choices made in the execution trace for this variant.
+   */
+  choices: ChoiceArray,
+
+  /**
+   * Information about the option selections in the execution trace for this variant.
+   */
+  options: OptionInfo[]
+}
+
+/**
+ * A group of variants for a particular type.
+ */
+type VariantGroup = {
+  /**
+   * The headers for the type, naming the type's fields.
+   * For non-record types, there should be only a single header naming that type.
+   */
+  headers: VariantFieldHeader[],
+
+  /**
+   * The records for the variants.
+   */
+  dataset: VariantRecord[]
+}
+
+/**
+ * The response from the server for a code evaluation.
+ */
+type WNResponse = {
+  /**
+   * The results of the evaluation, grouped by type.
+   */
+  groups: VariantGroup[],
+  
+  /**
+   * Any status messages (e.g. warnings) emitted during evaluation.
+   */
+  msg: string
+}
+
+/*
+ * CLIENT STATES
+ */
+
+/**
+ * Common fields for states that carry GF code.
+ */
+interface StateWithCode {
+  /**
+   * The QID of the focused Wikidata entity.
+   */
+  qid: string;
+
+  /**
+   * The target language for linearization.
+   */
+  lang: string;
+
+  /**
+   * The GF code snippet to evaluate.
+   */
+  code: string;
+}
+
+/**
+ * Common fields for states that carry information about choices.
+ */
+interface StateWithChoices extends StateWithCode {
+  /**
+   * A choice map for non-option choices (i.e. a trace).
+   */
+  choices: ChoiceMap;
+
+  /**
+   * A choice map for options.
+   */
+  opts: ChoiceMap;
+}
+
+/**
+ * The initial client state.
+ */
+type WNStateInitial = { state: "initial" }
+
+/**
+ * The client is waiting for a response from the server.
+ */
+type WNStateWaiting = StateWithChoices & { state: "waiting" }
+
+/**
+ * The client encountered an error while querying the server.
+ */
+type WNStateInvalid = StateWithChoices & {
+  state: "invalid",
+  
+  /**
+   * An error message.
+   */
+  error: string
+}
+
+/**
+ * The client received a response from the server and is ready to display it.
+ */
+type WNStateValid = StateWithCode & {
+  state: "valid",
+
+  /**
+   * The results received from the server.
+   */
+  groups: VariantGroup[]
+}
+
+/**
+ * The client has fixed a trace and is ready for option selection.
+ */
+type WNStateInteractive = StateWithChoices & {
+  state: "interactive",
+
+  /**
+   * The headers for the fixed trace's group.
+   */
+  headers: VariantFieldHeader[],
+  
+  /**
+   * The record for the fixed trace.
+   */
+  record: VariantRecord
+}
+
+/**
+ * A state for the WordNet client.
+ */
+type WNState = WNStateInitial | WNStateWaiting | WNStateInvalid | WNStateValid | WNStateInteractive
+
+/**
+ * Emitted when the state of the WordNet client changes.
+ */
+declare class WNStateChangeEvent extends Event {
+  /**
+   * The new state.
+   */
+  newState: WNState;
+  
+  constructor(newState: WNState);
+}
+
+/**
+ * Emitted when the WordNet client consumes a result from the server.
+ */
+declare class WNResultEvent extends Event {
+  /**
+   * The received result.
+   */
+  result: WNResponse;
+  
+  constructor(result: WNResponse);
+}
+
+/**
+ * A state machine for evaluating code on the WordNet server.
+ */
+declare class WNClient extends EventTarget {
+  /**
+   * Constructs a new state machine in the initial state.
+   */
+  constructor();
+
+  /**
+   * Updates the state, emitting a {@link WNStateChangeEvent} in the process.
+   * 
+   * @param state The new state.
+   */
+  setState(state: WNState);
+
+  /**
+   * Sets the target program for evaluation, sending a request to the server if necessary.
+   * 
+   * @param qid The QID of the focused Wikidata entity.
+   * @param lang The target language for linearization.
+   * @param code The GF code snippet to evaluate.
+   */
+  setProgram(qid: string, lang: string, code: string);
+
+  /**
+   * Fixes a program trace to allow for option selection.
+   * The trace is specified by a variant, which is given in the form of a record.
+   * 
+   * @param headers The field headers for the record's group.
+   * @param record The variant record for the interaction point.
+   */
+  setInteractionPoint(headers: VariantFieldHeader[], record: VariantRecord);
+
+  /**
+   * Sets an option for the current program, sending a request to the server if necessary.
+   * This should only be used after an interaction point has been set.
+   * 
+   * @param choice The choice ID for the option.
+   * @param index The new choice index to set for the option.
+   * @see WNClient#setInteractionPoint
+   */
+  setOption(choice: number, index: number);
+
+  /**
+   * Sends a request to the server to evaluate a snippet of code.
+   * 
+   * @param qid The QID of the focused Wikidata entity.
+   * @param lang The target language for linearization.
+   * @param code The GF code snippet to evaluate.
+   * @param choices The initial choices to use in evaluation (i.e. an execution trace prefix).
+   * @param opts The options to set in evaluation.
+   */
+  revalidate(qid: string, lang: string, code: string, choices: ChoiceMap, opts: ChoiceMap);
+
+  /**
+   * Loads a result received from the server.
+   * 
+   * @param result The result to load.
+   * @param qid The QID of the focused Wikidata entity.
+   * @param lang The target language for linearization.
+   * @param code The GF code snippet that was evaluated.
+   */
+  loadResult(result: WNResponse, qid: string, lang: string, code: string);
+}

--- a/www/js/gf-functions.js
+++ b/www/js/gf-functions.js
@@ -204,14 +204,14 @@ class WNClient extends EventTarget {
         }
     }
 
-    setOption(choice, value) {
+    setOption(choice, index) {
         switch (this.state.state) {
             case "interactive":
-                if (!Object.hasOwn(this.state.opts, choice) || this.state.opts[choice] === value) break;
+                if (!Object.hasOwn(this.state.opts, choice) || this.state.opts[choice] === index) break;
                 // falls through
             case "invalid":
                 const newOpts = {...this.state.opts};
-                newOpts[choice] = value;
+                newOpts[choice] = index;
                 // TODO delete dependent options
                 this.revalidate(this.state.qid, this.state.lang, this.state.code, this.state.choices, newOpts);
                 break;

--- a/www/js/gf-functions.js
+++ b/www/js/gf-functions.js
@@ -118,3 +118,142 @@ function loadEntity(qid, name) {
     content.dataset.qid = qid;
     content.innerText = qid+": "+name;
 }
+
+function serializeOptions(opts, choices) {
+    const arr = choices ? [...choices] : [];
+    for (const [c, i] of Object.entries(opts)) {
+        arr.push(parseInt(c, 10), i);
+    }
+    return arr;
+}
+
+function deserializeOptions(arr) {
+    if (arr.length % 2 !== 0) throw new Error(`Choice array must be of even length, but got ${arr.length}!`);
+    const opts = {};
+    for (let i = 0; i < arr.length; i += 2) {
+        opts[arr[i]] = arr[i + 1];
+    }
+    return opts;
+}
+
+class WordNetPageState {
+    constructor(elemOut, elemOpts) {
+        this.elemOut = elemOut;
+        this.elemOpts = elemOpts;
+        this.state = { state: "initial" };
+    }
+
+    setProgram(qid, lang, code) {
+        switch (this.state.state) {
+            case "initial":
+                this.revalidate(qid, lang, code, [], {});
+                break;
+            case "valid":
+                if (qid === this.state.qid && lang === this.state.lang && code === this.state.code) break;
+                this.revalidate(qid, lang, code, [], {});
+                break;
+            case "invalid":
+                if (qid === this.state.qid && lang === this.state.lang && code === this.state.code) {
+                    this.revalidate(qid, lang, code, this.state.choices, this.state.opts);
+                } else {
+                    this.revalidate(qid, lang, code, [], {});
+                }
+                break;
+        }
+    }
+
+    setOption(choice, value) {
+        switch (this.state.state) {
+            case "valid":
+                if (Object.hasOwn(this.state.opts, choice) && this.state.opts[choice] === value) break;
+                // falls through
+            case "invalid":
+                const newOpts = {...this.state.opts};
+                newOpts[choice] = value;
+                this.revalidate(this.state.qid, this.state.lang, this.state.code, this.state.choices, newOpts);
+                break;
+        }
+    }
+
+    revalidate(qid, lang, code, choices, opts) {
+        this.state = { state: "waiting", qid, lang, code, choices, opts };
+        this.elemOut.innerHTML = "<pre class=\"status\">Evaluating...</pre>";
+        this.elemOpts.innerHTML = "";
+        (async () => {
+            const request = { lang, code, choices: serializeOptions(opts, choices) };
+            if (qid) request.qid = qid;
+            const response = await fetch("FunctionsService.fcgi", {
+                method: "POST",
+                body: JSON.stringify(request),
+            });
+            if (response.status !== 200) throw new Error(await response.text());
+
+            const newOpts = {...opts};
+            let newChoices = null;
+            const result = await response.json();
+            this.elemOut.innerHTML = "";
+            this.elemOut.appendChild(node("pre",{},[text(result.msg)]));
+            if (result.groups.length == 0)
+                this.elemOut.appendChild(node("b",{},[text("No results")]));
+            let addedOpts = false;
+            for (const group of result.groups) {
+                const res_tbl = node("table",{"class": "dataset"},[]);
+                const row = []
+                for (const header of group.headers) {
+                    row.push(th([text(header.label)]));
+                }
+                res_tbl.appendChild(tr(row))
+                for (const record of group.dataset) {
+                    const row = []
+                    for (let i in record.fields) {
+                        const value  = record.fields[i];
+                        const header = group.headers[i];
+                        if (header.type == "markup") {
+                            const e = td([]);
+                            e.innerHTML = value;
+                            row.push(e);
+                        } else if (header.type == "number") {
+                            row.push(node("td",{style: "text-align: right"},[text(value)]));
+                        } else if (header.type == "string") {
+                            row.push(td([text(value)]));
+                        } else if (header.type == "text") {
+                            row.push(td(node("pre",{},[text(value)])));
+                        }
+                    }
+                    res_tbl.appendChild(tr(row))
+
+                    if (!addedOpts && record.options && record.options.length) {
+                        const optElems = [];
+                        const validOptChoices = new Set();
+                        for (const opt of record.options) {
+                            validOptChoices.add(opt.choice.toString());
+                            const optBody = [node("div", { "class": "option-header" }, [node("b", {}, [text(opt.label)])])];
+                            const selected = opts[opt.choice] || 0;
+                            newOpts[opt.choice] = selected;
+                            for (let i = 0; i < opt.options.length; i++) {
+                                const valueElem = node("div", { "class": "option-value" }, [text(opt.options[i])]);
+                                if (i === selected) valueElem.classList.add("selected");
+                                valueElem.onclick = () => this.setOption(opt.choice, i);
+                                optBody.push(valueElem)
+                            }
+                            optElems.push(node("div", { "class": "option" }, optBody));
+                        }
+                        for (const c of Object.keys(opts)) {
+                            if (!validOptChoices.has(c)) {
+                                delete newOpts[c];
+                            }
+                        }
+                        newChoices = record.choices;
+                        this.elemOpts.appendChild(node("div", { "class": "option-container" }, optElems));
+                        addedOpts = true;
+                    }
+                }
+                this.elemOut.appendChild(res_tbl);
+            }
+            this.state = { state: "valid", qid, lang, code, choices: newChoices, opts: newOpts };
+        })().catch(error => {
+            this.state = { state: "invalid", qid, lang, code, choices, opts };
+            this.elemOut.innerHTML = `<pre class="status">${error}</pre>`;
+        });
+    }
+}


### PR DESCRIPTION
This PR:
* adds support for options to the JSON web API
* adds a small JS client library for consuming the web API
* refactors the page renderer to embed page data as JSON which can be processed in client code (instead of raw HTML)

It doesn't address the wikidata caching issue yet; my plan is to redesign `EvalM` in gf-core as a monad transformer so that we can run wordnet in some kind of stateful monad that lets us keep track of pending and completed requests, which will help with both caching and with the previously-discussed bulk request idea

Of course, there is still more frontend stuff necessary to make the GFpedia templates work with the new system